### PR TITLE
Support Repo priority.

### DIFF
--- a/cpenv/cli/repo.py
+++ b/cpenv/cli/repo.py
@@ -20,6 +20,7 @@ class Repo(core.CLI):
             ListRepo(self),
             AddRepo(self),
             RemoveRepo(self),
+            EditRepos(self),
         ]
 
 
@@ -163,3 +164,16 @@ class RemoveRepo(core.CLI):
         api.write_config('repos', repo_config)
         core.echo('OK!')
         core.echo()
+
+
+class EditRepos(core.CLI):
+    '''Open repos config in text editor.'''
+
+    name = 'edit'
+
+    def run(self, args):
+
+        config_path = api.get_config_path()
+        editor = os.getenv('CPENV_EDITOR', os.getenv('EDITOR', 'subl'))
+        core.echo('Opening %s in %s.' % (config_path, editor))
+        shell.run(editor, config_path)

--- a/cpenv/cli/repo.py
+++ b/cpenv/cli/repo.py
@@ -1,7 +1,8 @@
 import argparse
+import os
 import re
 
-from cpenv import api, repos
+from cpenv import api, repos, shell
 from cpenv.cli import core
 
 
@@ -71,6 +72,12 @@ class AddRepo(core.CLI):
             help='Name of the repo',
         )
         parser.add_argument(
+            '--priority',
+            help='Priority of repo - the lower the priority the earlier in the list of repos the repo will appear.',
+            default=None,
+            type=int,
+        )
+        parser.add_argument(
             'type_args',
             help='Type specific arguments.',
             nargs=argparse.REMAINDER,
@@ -108,6 +115,7 @@ class AddRepo(core.CLI):
 
         repo_cls = repos.registry[repo_type]
         repo_kwargs['name'] = args.name
+        repo_kwargs['priority'] = args.priority
         core.echo('- Checking %s args...' % repo_cls.__name__, end='')
         try:
             repo_cls(**repo_kwargs)

--- a/cpenv/repos/base.py
+++ b/cpenv/repos/base.py
@@ -10,8 +10,9 @@ class Repo(object):
 
     type_name = 'repo'
 
-    def __init__(self, name):
+    def __init__(self, name, priority=10):
         self.name = name
+        self.priority = priority
 
     def __repr__(self):
         args = []

--- a/cpenv/repos/local.py
+++ b/cpenv/repos/local.py
@@ -34,8 +34,8 @@ class LocalRepo(Repo):
 
     type_name = 'local'
 
-    def __init__(self, name, path):
-        super(LocalRepo, self).__init__(name)
+    def __init__(self, name, path, priority=10):
+        super(LocalRepo, self).__init__(name, priority)
         self.path = paths.normalize(path)
         self.cache = TTLCache(maxsize=10, ttl=60)
 

--- a/cpenv/repos/shotgun.py
+++ b/cpenv/repos/shotgun.py
@@ -64,8 +64,9 @@ class ShotgunRepo(Repo):
         api_key=None,
         api=None,
         module_entity='CustomNonProjectEntity01',
+        priority=20,
     ):
-        super(ShotgunRepo, self).__init__(name)
+        super(ShotgunRepo, self).__init__(name, priority)
         if api:
             # Assume we've received a Shotgun instance
             # This will be done via the tk-cpenv shotgun app


### PR DESCRIPTION
This PR adds support for ordering repositories by priority. This gives users full control over the order in which modules are resolved. For example, as a developer I can now force my LocalRepo containing all my modules in development to be looked at first during module resolution by setting the priority to -1.

`cpenv repo add --type=local --priority=-1 dev_repo --path="/path/to/my/dev/repos"`

Default priorities:
- LocalRepo: 10
- ShotgunRepo: 20

Bonus:
- Added `cpenv repo edit` cli command to quickly launch your config file containing custom repositories in your text editor.