### PR TITLE
Fix localize reporting.

### DIFF
--- a/cpenv/resolver.py
+++ b/cpenv/resolver.py
@@ -195,16 +195,16 @@ class Localizer(object):
             raise ValueError("Localizer expected LocalRepo got %s" % type(to_repo))
 
     def localize(self, module_specs, overwrite=False):
-        """Given ModuleSpecs, download them to this Localizers repo."""
+        '''Given ModuleSpecs, download them to this Localizers repo.'''
 
         self.reporter.start_localize(module_specs)
         localized = []
         for module_spec in module_specs:
+            self.reporter.localize_module(module_spec, None)
 
             # Module is already local
             if isinstance(module_spec.repo, LocalRepo):
                 localized.append(Module(module_spec.path))
-                self.reporter.localize_module(module_spec, localized[-1])
                 continue
 
             # Module already exists in to_repo
@@ -214,16 +214,16 @@ class Localizer(object):
                 if is_exact_match(module_spec.qual_name, match):
                     already_exists = True
                     localized.append(Module(match.path))
-                    self.reporter.localize_module(module_spec, localized[-1])
                     break
 
             if already_exists and not overwrite:
-                self.reporter.localize_module(module_spec, localized[-1])
                 continue
 
             # Generate a new module path in to_repo
             if module_spec.version.string in module_spec.real_name:
-                new_module_path = self.to_repo.relative_path(module_spec.real_name)
+                new_module_path = self.to_repo.relative_path(
+                    module_spec.real_name
+                )
             else:
                 new_module_path = self.to_repo.relative_path(
                     module_spec.name,
@@ -236,7 +236,6 @@ class Localizer(object):
                 overwrite=overwrite,
             )
             localized.append(module)
-            self.reporter.localize_module(module_spec, localized[-1])
 
         self.reporter.end_localize(localized)
 


### PR DESCRIPTION
Fixes #50.

The order of reporting calls while localizing modules was incorrect and could result in an incorrect module being displayed while downloading.