### PR TITLE
Fix subshell.sh line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+# Default line ending behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Files that will always have CRLF line endings on checkout.
+# Windows command files
+*.bat text eol=crlf
+*.cmd text eol=crlf
+
+# Files that will always have LF line endings on checkout.
+# Linux command files
+*.sh text eol=lf
+*.env text eol=lf


### PR DESCRIPTION
by adding a `.gitattributes` file which ensures that script files always get the right line endings with in each operating system. Once this file is present the line endings will be fixed in the `subshell.sh` script.

Fixes #58 
