### PR TITLE
Adjust test workflow.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,21 +24,22 @@ jobs:
         python-version: ['3.7', '3.8', '3.9', '3.10']
       fail-fast: false
     steps:
-      - uses: actions/checkout@v2
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
+      - uses: actions/checkout@v3
 
       - name: Install poetry
-        run: python -m pip install poetry
+        run: pipx install poetry
+
+      - name: Set up Python ${{ matrix.python-version }}
+        id: setup_python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'poetry'
 
       - name: Install dependencies
-        run: poetry install
-
-      - name: Install annotate-failures plugin
-        run: poetry run pip install pytest-github-actions-annotate-failures
+        run: |
+          poetry env use ${{ steps.setup_python.outputs.python-path }}
+          poetry install
 
       - name: Run tests
         run: poetry run python -m tasks test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'poetry'
+          cache-dependency-path: 'pyproject.toml'
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
- Drop Python 3.6 from test matrix.
- Cache test dependencies to speed up test workflow.