### PR TITLE
Overwriting env vars in pre-activate hook

### DIFF
--- a/cpenv/module.py
+++ b/cpenv/module.py
@@ -8,7 +8,7 @@ from collections import namedtuple
 from string import Template
 
 # Local imports
-from . import compat, paths
+from . import compat, paths, mappings
 from .hooks import HookFinder, get_global_hook_path
 from .vendor import yaml
 from .versions import ParseError, Version, default_version, parse_version
@@ -65,6 +65,7 @@ class Module(object):
         self._raw_config = None
         self._config = None
         self._env = None
+        self.env_overwrite = {}
 
         # Determine name, version, qual_name, and real_name
 
@@ -150,15 +151,6 @@ class Module(object):
         if hook:
             return hook.run(self)
 
-    def activate(self):
-        """Add this module to active modules"""
-
-        from . import api
-
-        self.run_hook("pre_activate")
-        api.add_active_module(self)
-        self.run_hook("post_activate")
-
     def remove(self):
         """Delete this module"""
 
@@ -224,11 +216,11 @@ class Module(object):
             self._env = self.config.get("environment", {})
             self._env["CPENV_ACTIVE_MODULES"] = {"append": self.real_name}
 
-        return self._env
+        return mappings.join_dicts(self._env, self.env_overwrite)
 
     @property
     def requires(self):
-        return self.config.get("email", [])
+        return self.config.get("requires", [])
 
     @property
     def icon(self):

--- a/cpenv/resolver.py
+++ b/cpenv/resolver.py
@@ -108,13 +108,21 @@ class Activator(object):
 
     def activate(self, module_specs):
         """Activate a list of module specs."""
+        from . import api
 
         modules = self.localizer.localize(module_specs)
+
+        for module in modules:
+            module.run_hook("pre_activate")
+
         env = self.combine_modules(modules)
         mappings.set_env(env)
 
         for module in modules:
-            module.activate()
+            api.add_active_module(module)
+
+        for module in modules:
+            module.run_hook("post_activate")
 
         return modules
 


### PR DESCRIPTION
This is a proof of concept for overwriting environment variables in pre-activate hooks. 

## What changed
- I moved the activate logic entirely to the Activator class and removed the activate function from the Module class
- I run the "pre_activate" hooks before the environment is combined 
- The "post_acitvate" hooks are run after **all** modules are active
- I added a new instance variable "env_overwrite" on the Module class
  Whatever you set in this dictionary will overwrite whats defined in the module.yml
- I fixed a small bug where the "requires" property of a Module returns the "email"

## How it works in practice 
You can now define a pre_activate hook like this:
```python
def run(module):
    if True:
        module.env_overwrite['SOME_VAR'] = 456
```
This would set `SOME_VAR` to 456 when the module is activated. The variable also propagates to subsequent modules.

## Closing thoughts
This proof does work, but I don't know if it causes any trouble for existing workflows. @danbradham you probably have more insight on this. Also there are no tests for this (yet). All current tests run without fail. 
The "env_overwrite" variable on the modules is a bit clunky IMO. It would be nice to use the "environment" property directly since that'd be way more intuitive, but I did not find a good way to marry the config read logic with the setting of the environment at runtime. Maybe you have some better ideas?
@danbradham feel free to rip this apart or throw it out if you want to implement your own logic. Any feedback is welcome. :slightly_smiling_face:  