### PR TITLE
Add support for large modules.

### DIFF
--- a/cpenv/cli/publish.py
+++ b/cpenv/cli/publish.py
@@ -52,9 +52,14 @@ class Publish(core.CLI):
 
         # Publish
         module = Module(module_spec.path)
-        published = to_repo.upload(module, args.overwrite)
-        core.echo()
+        try:
+            published = to_repo.upload(module, args.overwrite)
+        except Exception as e:
+            core.echo()
+            core.echo("{}: {}".format(type(e).__name__, e))
+            return
 
+        core.echo()
         core.echo("Activate your module:")
         core.echo("  cpenv activate %s" % published.real_name)
         core.echo()


### PR DESCRIPTION
This PR adds supports for modules larger than 2.14gb or 2147483647 bytes. 

Fixes #68 

To enable large modules you must convert your `sg_archive_size` field from a number field to a text field. The existing values should be preserved when you switch, but you may want to export your Module Entity list as a csv for safety.