### PR TITLE
Make lockfiles opt-in instead of defaulting to on.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Cpenv is a cli tool and python library used to create, edit, publish, and activa
 | CPENV_DISABLE_PROMPT     | Disable prompt when modules activated  | 0       |
 | CPENV_ACTIVE_MODULES     | List of activated modules              |         |
 | CPENV_SHELL              | Preferred subshell like "powershell"   |         |
+| CPENV_ENABLE_LOCKFILES   | Enable lockfiles during localization   | 0       |
 
 ## Example Modules
 - [snack](https://github.com/cpenv/snack)
@@ -192,3 +193,6 @@ Requirements are strings used to resolve and activate modules in Repos. They can
 version like `my_module-0.1.0`. Cpenv supports semver/calver, simple versions (v1), and what I like to call *weird* versions
 like 12.0v2 (The Foundry products). In the future cpenv may support more complex requirements by utilizing
 [resolvelib](https://github.com/sarugaku/resolvelib).
+
+# Locking
+It may be desirable to have interprocess locking around module localization. One use case I've run into is with Deadline rendering on workers with multiple gpus. In that case, a single worker may be rendering multiple frames simultaneously, and therefore, it's possible that the worked may try to download the same module at the same time. To enable interprocess locking via lockfiles, set the environment variable `CPENV_ENABLE_LOCKFILES` to 1.

--- a/cpenv/resolver.py
+++ b/cpenv/resolver.py
@@ -9,7 +9,7 @@ import shlex
 from . import mappings, paths
 from .module import Module, best_match, is_exact_match, is_module
 from .reporter import get_reporter
-from .repos import LocalRepo, RemoteRepo
+from .repos import LocalRepo
 from .vendor.fasteners import InterProcessLock
 
 __all__ = [
@@ -253,12 +253,19 @@ class Localizer(object):
         return localized
 
 
+def lock_required(repo):
+    """Check if locks are enabled..."""
+    try:
+        return isinstance(repo, LocalRepo) and int(os.getenv("CPENV_ENABLE_LOCKFILES", 0))
+    except Exception:
+        return 0
+
+
 @contextlib.contextmanager
 def ModuleInterProcessLock(repo, module_spec):
 
     # We can only create locks in LocalRepos
-    repo_supports_locks = isinstance(repo, LocalRepo)
-    if repo_supports_locks:
+    if lock_required(repo):
 
         # Acquire a lock for the module_spec so other processes / users
         # pointing at the same to_repo location do not step on each others toes.


### PR DESCRIPTION
This PR addresses issues introduced by locking in the previous release by making locking Opt-In. Set the environment variable `CPENV_ENABLE_LOCKFILES` to 1 to enable lockfiles and ensure that only 1 process on a given machine can localize a module at a time.

There seems to have been issues of file-ownership on machines with multiple users where one user could create a lock while localizing a module, and later another user would be unable to activate the same module.

Fixes #73 

Autocpenv and tk-cpenv will be updated shortly.